### PR TITLE
graphicconfig: change the scissor type from vec to ivec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 - `pynopegl` log levels are now controled using the `pynopegl.Log` enum
 - `max_texture_dimensions_*` capabilities are renamed to `max_texture_dimension_*`
 - Backend probing in `pynopegl` now returns a more Pythonic output
+- `GraphicConfig.scissor` is now an `ivec4` parameter instead of `vec4`
 
 ### Removed
 - `ResourceProps.variadic` bool flag as it was never a functional interface

--- a/libnopegl/doc/libnopegl.md
+++ b/libnopegl/doc/libnopegl.md
@@ -437,7 +437,7 @@ Parameter | Flags | Type | Description | Default
 `stencil_depth_pass` |  | [`stencil_operation`](#stencil_operation-choices) | operation to execute if stencil and depth test pass | `unset`
 `cull_mode` |  | [`cull_mode`](#cull_mode-choices) | face culling mode | `unset`
 `scissor_test` |  | [`bool`](#parameter-types) | enable scissor testing | `unset`
-`scissor` |  | [`vec4`](#parameter-types) | define an area where all pixels outside are discarded | (`-1`,`-1`,`-1`,`-1`)
+`scissor` |  | [`ivec4`](#parameter-types) | define an area where all pixels outside are discarded | (`-1`,`-1`,`-1`,`-1`)
 
 
 **Source**: [src/node_graphicconfig.c](/libnopegl/src/node_graphicconfig.c)

--- a/libnopegl/nodes.specs
+++ b/libnopegl/nodes.specs
@@ -910,8 +910,8 @@
     },
     {
       "name": "scissor",
-      "type": "vec4",
-      "default": [-1.000000,-1.000000,-1.000000,-1.000000],
+      "type": "ivec4",
+      "default": [-1,-1,-1,-1],
       "flags": [],
       "desc": "define an area where all pixels outside are discarded"
     }

--- a/libnopegl/src/node_graphicconfig.c
+++ b/libnopegl/src/node_graphicconfig.c
@@ -58,16 +58,15 @@ struct graphicconfig_opts {
     int cull_mode;
 
     int scissor_test;
-    float scissor_f[4];
+    int scissor[4];
 };
 
 struct graphicconfig_priv {
     struct graphicstate graphicstate;
     int use_scissor;
-    int scissor[4];
 };
 
-#define DEFAULT_SCISSOR_F {-1.0f, -1.0f, -1.0f, -1.0f}
+#define DEFAULT_SCISSOR {-1, -1, -1, -1}
 
 static const struct param_choices blend_factor_choices = {
     .name = "blend_factor",
@@ -213,7 +212,7 @@ static const struct node_param graphicconfig_params[] = {
                            .desc=NGLI_DOCSTRING("face culling mode")},
     {"scissor_test",       NGLI_PARAM_TYPE_BOOL,   OFFSET(scissor_test),       {.i32=-1},
                            .desc=NGLI_DOCSTRING("enable scissor testing")},
-    {"scissor",            NGLI_PARAM_TYPE_VEC4, OFFSET(scissor_f), {.vec=DEFAULT_SCISSOR_F},
+    {"scissor",            NGLI_PARAM_TYPE_IVEC4, OFFSET(scissor), {.ivec=DEFAULT_SCISSOR},
                            .desc=NGLI_DOCSTRING("define an area where all pixels outside are discarded")},
     {NULL}
 };
@@ -235,11 +234,8 @@ static int graphicconfig_init(struct ngl_node *node)
         return NGL_ERROR_INVALID_USAGE;
     }
 
-    static const float default_scissor[4] = DEFAULT_SCISSOR_F;
-    s->use_scissor = memcmp(o->scissor_f, default_scissor, sizeof(o->scissor_f));
-    const float *sf = o->scissor_f;
-    const int scissor[4] = {(int)sf[0], (int)sf[1], (int)sf[2], (int)sf[3]};
-    memcpy(s->scissor, scissor, sizeof(s->scissor));
+    static const int default_scissor[4] = DEFAULT_SCISSOR;
+    s->use_scissor = memcmp(o->scissor, default_scissor, sizeof(o->scissor));
 
     return 0;
 }
@@ -308,7 +304,7 @@ static void graphicconfig_draw(struct ngl_node *node)
     int prev_scissor[4];
     if (s->use_scissor) {
         ngli_gpu_ctx_get_scissor(gpu_ctx, prev_scissor);
-        ngli_gpu_ctx_set_scissor(gpu_ctx, s->scissor);
+        ngli_gpu_ctx_set_scissor(gpu_ctx, o->scissor);
     }
 
     ngli_node_draw(o->child);


### PR DESCRIPTION
The scissor parameter was implemented before the NGLI_PARAM_TYPE_IVEC* types were available. Switching to IVEC4 matches the internal scissor type.