### PR TITLE
hmap, darray: fix invalid shifts

### DIFF
--- a/libnopegl/src/darray.c
+++ b/libnopegl/src/darray.c
@@ -87,7 +87,7 @@ void *ngli_darray_push(struct darray *darray, const void *element)
             return NULL;
 #else
         /* Also includes the realloc overflow check */
-        if (darray->capacity >= 1 << (sizeof(darray->capacity)*8 - 2))
+        if (darray->capacity >= 1ULL << (sizeof(darray->capacity)*8 - 2))
             return NULL;
         size_t new_capacity = darray->capacity * 2;
 #endif

--- a/libnopegl/src/hmap.c
+++ b/libnopegl/src/hmap.c
@@ -235,7 +235,7 @@ int ngli_hmap_set(struct hmap *hm, const char *key, void *data)
             return NGL_ERROR_LIMIT_EXCEEDED;
 #else
         /* Also includes the realloc overflow check */
-        if (hm->size >= 1 << (sizeof(hm->size)*8 - 2))
+        if (hm->size >= 1ULL << (sizeof(hm->size)*8 - 2))
             return NGL_ERROR_LIMIT_EXCEEDED;
         size_t new_size = hm->size * 2;
 #endif


### PR DESCRIPTION
Fixes the following warnings on Windows:
- hmap.c(241,54): warning C4293: '<<': shift count negative or too big, undefined behavior
- darray.c(90,70): warning C4293: '<<': shift count negative or too big, undefined behavior

Fixes runtime errors on Windows due to regressions introduced by 609332e822b0c0afb766cef2dd975741c7ecd0c5 and
081ace38da7f29871906c7d44db351dd96a97a32.