### PR TITLE
gl: make glInvalidateFramebuffer() non-mandatory

### DIFF
--- a/libnopegl/scripts/gen-gl-wrappers.py
+++ b/libnopegl/scripts/gen-gl-wrappers.py
@@ -65,6 +65,8 @@ cmds_optional = [
     "glGetQueryObjectui64vEXT",
     # EGL OES image
     "glEGLImageTargetTexture2DOES",
+    # Invalidate subdat
+    "glInvalidateFramebuffer",
 ]
 
 cmds = [
@@ -124,7 +126,6 @@ cmds = [
     "glGenFramebuffers",
     "glReadPixels",
     "glBlitFramebuffer",
-    "glInvalidateFramebuffer",
     "glGetFramebufferAttachmentParameteriv",
     "glFramebufferTexture3D",
     "glFramebufferTextureLayer",

--- a/libnopegl/src/backends/gl/gldefinitions_data.h
+++ b/libnopegl/src/backends/gl/gldefinitions_data.h
@@ -118,7 +118,7 @@ static const struct gldefinition {
     {"glGetUniformBlockIndex", offsetof(struct glfunctions, GetUniformBlockIndex), M},
     {"glGetUniformLocation", offsetof(struct glfunctions, GetUniformLocation), M},
     {"glGetUniformiv", offsetof(struct glfunctions, GetUniformiv), M},
-    {"glInvalidateFramebuffer", offsetof(struct glfunctions, InvalidateFramebuffer), M},
+    {"glInvalidateFramebuffer", offsetof(struct glfunctions, InvalidateFramebuffer), 0},
     {"glLinkProgram", offsetof(struct glfunctions, LinkProgram), M},
     {"glMapBufferRange", offsetof(struct glfunctions, MapBufferRange), M},
     {"glMemoryBarrier", offsetof(struct glfunctions, MemoryBarrier), 0},


### PR DESCRIPTION
glInvalidateFramebuffer() is only present if GL_ARB_invalidate_subdata is supported, which is not the case on macOS.

Fixes a regression introduced by 9fb1c47a60375bc2fc343a763327601aed671fcb.