### PR TITLE
gpu_ctx_vk: advertise support for NGLI_FEATURE_TEXTURE_{HALF_FLOAT,FL…

### DIFF
--- a/libnopegl/src/backends/vk/gpu_ctx_vk.c
+++ b/libnopegl/src/backends/vk/gpu_ctx_vk.c
@@ -883,7 +883,9 @@ static int vk_init(struct gpu_ctx *s)
     s->features = NGLI_FEATURE_COMPUTE |
                   NGLI_FEATURE_IMAGE_LOAD_STORE |
                   NGLI_FEATURE_STORAGE_BUFFER |
-                  NGLI_FEATURE_BUFFER_MAP_PERSISTENT;
+                  NGLI_FEATURE_BUFFER_MAP_PERSISTENT |
+                  NGLI_FEATURE_TEXTURE_FLOAT_RENDERABLE |
+                  NGLI_FEATURE_TEXTURE_HALF_FLOAT_RENDERABLE;
 
     struct vkcontext *vk = s_priv->vkcontext;
     const VkPhysicalDeviceLimits *limits = &vk->phy_device_props.limits;


### PR DESCRIPTION
…OAT}_RENDERABLE

The vulkan 1.1 specification¹ mandates the following formats to be color renderable (and that they support linear filtering):
- VK_FORMAT_R16_SFLOAT
- VK_FORMAT_R16G16_SFLOAT
- VK_FORMAT_R16G16B16A16_SFLOAT
- VK_FORMAT_R32_SFLOAT
- VK_FORMAT_R32G32_SFLOAT
- VK_FORMAT_R32G32B32A32_FLOAT

[1]: https://registry.khronos.org/vulkan/specs/1.1/html/vkspec.html#features-required-format-support