### PR TITLE
ci: wait for Vulkan installers to finish before proceeding further

### DIFF
--- a/.github/workflows/ci_msvc.yml
+++ b/.github/workflows/ci_msvc.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Install dependencies
         run: |
           iwr https://sdk.lunarg.com/sdk/download/${{env.VULKAN_SDK_VERSION}}/windows/VulkanSDK-${{env.VULKAN_SDK_VERSION}}-Installer.exe -OutFile VulkanSDK-Installer.exe
-          .\VulkanSDK-Installer.exe --accept-licenses --default-answer --confirm-command install
+          .\VulkanSDK-Installer.exe --accept-licenses --default-answer --confirm-command install | Out-Null
 
           iwr https://sdk.lunarg.com/sdk/download/${{env.VULKAN_SDK_VERSION}}/windows/VulkanRT-${{env.VULKAN_SDK_VERSION}}-Installer.exe -OutFile VulkanRT-Installer.exe
-          .\VulkanRT-Installer.exe /S
+          .\VulkanRT-Installer.exe /S | Out-Null
 
       - name: Build (${{matrix.build_backend}})
         run: |


### PR DESCRIPTION
The installers are GUI based meaning we might get control back before the install ends. This causes the vulkan DLL not to be available during configure, causing all kind of runtime linking issues.

See https://stackoverflow.com/questions/7908000/run-an-application-with-powershell-and-wait-until-it-is-finished for more information on the hack.

Debugged and analyzed with Matthieu Bouron.