### PR TITLE
ci: disable fast failing on linux and msvc

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - backend: "all"

--- a/.github/workflows/ci_msvc.yml
+++ b/.github/workflows/ci_msvc.yml
@@ -16,6 +16,7 @@ jobs:
     env:
         VULKAN_SDK_VERSION: 1.3.250.1
     strategy:
+      fail-fast: false
       matrix:
         include:
           - build_backend: ninja


### PR DESCRIPTION
It makes sense to test the whole matrix even if one fails.