### PR TITLE
tests: increase the timeout multiplier again

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -68,7 +68,7 @@ jobs:
       run: |
         ${{matrix.custom_env}} make tests-setup
         . venv/bin/activate
-        ${{matrix.custom_env}} meson test -C builddir/tests --timeout-multiplier=2 ${{matrix.custom_args}}
+        ${{matrix.custom_env}} meson test -C builddir/tests --timeout-multiplier=3 ${{matrix.custom_args}}
 
     - name: Upload Logs
       if: ${{ always() }}

--- a/configure.py
+++ b/configure.py
@@ -561,7 +561,7 @@ def _coverage_xml(cfg):
 
 @_block("tests", [_nopegl_tests, _tests_setup])
 def _tests(cfg):
-    return ["$(MESON) " + _cmd_join("test", "--timeout-multiplier", "2", "-C", op.join("builddir", "tests"))]
+    return ["$(MESON) " + _cmd_join("test", "-C", op.join("builddir", "tests"))]
 
 
 def _quote(s):


### PR DESCRIPTION
Since a few days it seems the Github Actions CI resources got reduced. Starting from the HISTORY.md commit (87316921) the tests timings went from:

  2023-08-03T12:44:59.7264391Z  41/984 ngl-tests:opengl+benchmark / fingerprint_with_compute       OK             23.93s
  2023-08-03T12:49:13.3936743Z 700/984 ngl-tests:vulkan+benchmark / fingerprint_with_compute       OK             29.10s

To:

  2023-08-08T09:36:27.2987889Z  42/984 ngl-tests:opengl+benchmark / fingerprint_with_compute       OK             35.31s
  2023-08-08T09:42:22.5686176Z 699/984 ngl-tests:vulkan+benchmark / fingerprint_with_compute       OK             58.74s

The Vulkan tests are dangerously close to the 60 seconds timeout limit, which is sometimes reached. While there is certainly room for performance improvements in nopegl, this regressoin doesn't seem to be our fault, but rather something on Github side.